### PR TITLE
First version of long term patroller

### DIFF
--- a/waypoint_patroller/CMakeLists.txt
+++ b/waypoint_patroller/CMakeLists.txt
@@ -4,7 +4,7 @@ project(waypoint_patroller)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs move_base_msgs rospy)
+find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs move_base_msgs rospy scitos_msgs scitos_apps_msgs std_msgs)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/waypoint_patroller/launch/long_term_patroller.launch
+++ b/waypoint_patroller/launch/long_term_patroller.launch
@@ -1,0 +1,10 @@
+<launch>
+
+    <arg name="waypoints"/>
+    <arg name="randomized" default="true"/>
+
+    
+
+
+    <node name="patroller" pkg="waypoint_patroller" type="long_term_patroller.py" output="screen" args="$(arg waypoints) $(arg randomized)"/>
+</launch>

--- a/waypoint_patroller/package.xml
+++ b/waypoint_patroller/package.xml
@@ -44,10 +44,18 @@
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>move_base_msgs</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>scitos_msgs</build_depend>
+  <build_depend>scitos_apps_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>move_base_msgs</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>scitos_msgs</run_depend>
+  <run_depend>scitos_apps_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+  
+
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/waypoint_patroller/scripts/charging.py
+++ b/waypoint_patroller/scripts/charging.py
@@ -1,0 +1,150 @@
+import rospy
+
+import smach
+import smach_ros
+
+from geometry_msgs.msg import Twist
+
+
+from scitos_apps_msgs.srv import Charging
+
+from monitor_states import bumper_monitor
+from monitor_states import battery_monitor
+from recover_states import RecoverBumper
+
+
+class DockToChargingStation(smach.State):
+    def __init__(self):
+        smach.State.__init__(self,
+            outcomes    = ['succeeded','failure','preempted'],            
+        )
+
+        self.dock_behaviour = rospy.ServiceProxy('chargingSrv', Charging)
+
+    def execute(self,userdata):
+        self.dock_behaviour('charge',100)
+        if self.preempt_requested():
+            self.service_preempt()
+            return 'preempted'
+        #add failure    
+        return 'succeeded'
+        
+        
+  
+  
+
+          
+  
+  
+  
+class UndockFromChargingStation(smach.State):
+    def __init__(self):
+        smach.State.__init__(self,
+            outcomes    = ['succeeded','failure','preempted'],            
+        )
+        self.vel_pub = rospy.Publisher('/cmd_vel', Twist)
+        self._vel_cmd = Twist()
+        self._vel_cmd.linear.x=-0.2
+
+
+    def execute(self,userdata):
+        for i in range(0,20): 
+            self.vel_pub.publish(self._vel_cmd)
+            if self.preempt_requested():
+                self.service_preempt()
+                return 'preempted'
+            rospy.sleep(0.1)
+            
+    
+
+        return 'succeeded'
+        
+        
+        
+#states used onnly for tests. replace by battery_monitor  
+class ChargingState(smach.State):
+    def __init__(self):
+        smach.State.__init__(self,
+            outcomes    = ['invalid','valid'],            
+        )
+        
+        #self.reset_motorstop = rospy.ServiceProxy('reset_motorstop', ResetMotorStop)
+
+
+    def execute(self,userdata):
+        rospy.sleep(3)
+
+        return 'invalid'
+                
+  
+def child_term_cb(outcome_map):
+    return True
+ 
+def out_cb(outcome_map):
+    if outcome_map['BUMPER_MONITOR'] == 'invalid':
+        return 'bumper_pressed'
+    if  outcome_map["UNMONITORED_DOCKING"]=="succeeded":
+        return "succeeded"
+
+
+
+def monitored_docking():
+    
+    conc=smach.Concurrence(outcomes=['bumper_pressed','succeeded','failure'],
+                                                    default_outcome='failure',
+                                                    child_termination_cb=child_term_cb,
+                                                    outcome_cb = out_cb,
+                                                    input_keys=['going_to_charge','n_recover_tries_in'],
+                                                    output_keys=['n_recover_tries_out'])
+                                                    
+    with conc:                                                
+    
+        unmonitored_dock=smach.StateMachine(outcomes=['succeeded','failure','preempted'],input_keys=['going_to_charge'])    
+        with unmonitored_dock:
+            smach.StateMachine.add('DOCK_TO_CHARGING_STATION',DockToChargingStation(), transitions={'succeeded':'CHARGING','failure':'DOCK_TO_CHARGING_STATION'} )
+            smach.StateMachine.add('CHARGING',battery_monitor(), transitions={'invalid':'UNDOCK_FROM_CHARGING_STATION','valid':'UNDOCK_FROM_CHARGING_STATION'} )
+           #smach.StateMachine.add('CHARGING',ChargingState(), transitions={'invalid':'UNDOCK_FROM_CHARGING_STATION','valid':'CHARGING'} ) #test: change afterwards
+            smach.StateMachine.add('UNDOCK_FROM_CHARGING_STATION',UndockFromChargingStation(), transitions={'succeeded':'succeeded','failure':'UNDOCK_FROM_CHARGING_STATION'} )
+            
+        
+        smach.Concurrence.add('UNMONITORED_DOCKING',unmonitored_dock)
+        smach.Concurrence.add('BUMPER_MONITOR',bumper_monitor())
+        
+    return conc    
+    
+    
+    
+    
+def dock_and_charge():
+    
+    docking_sm=smach.StateMachine(outcomes=['succeeded','failure'], input_keys=['going_to_charge'])
+    
+    with docking_sm:
+        
+        smach.StateMachine.add('MONITORED_DOCK',monitored_docking(), transitions={'succeeded':'succeeded','failure':'failure','bumper_pressed':'RECOVER_BUMPER'},
+                                remapping={'n_recover_tries_out':'prev_tries', 'n_recover_tries_in':'cur_tries'})
+        smach.StateMachine.add('RECOVER_BUMPER', RecoverBumper(),  transitions={'succeeded':'MONITORED_DOCK'},
+                                remapping={'n_recover_tries_in':'prev_tries', 'n_recover_tries_out':'cur_tries'})
+        
+    return docking_sm
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    

--- a/waypoint_patroller/scripts/long_term_patroller.py
+++ b/waypoint_patroller/scripts/long_term_patroller.py
@@ -1,0 +1,140 @@
+#! /usr/bin/env python
+import sys
+from random import randint
+import rospy
+import csv
+
+import smach
+import smach_ros
+
+
+from navigation import navigation
+from charging import dock_and_charge
+
+from scitos_msgs.msg import BatteryState
+
+
+
+CHARGE_BATTERY_TRESHOLD=20
+
+
+class PointChooser(smach.State):
+    def __init__(self, waypoints_name,is_random):
+        smach.State.__init__(self,
+            outcomes    = ['patrol','go_charge'],
+            output_keys=['goal_pose','going_to_charge']
+        )
+        
+        
+        
+
+
+        self.points=[]
+        with open(waypoints_name, 'rb') as csvfile:
+                reader = csv.reader(csvfile, delimiter=',')
+                for row in reader:
+                        current_row=[]
+                        for element in row:
+                                current_row.append(float(element))
+                        self.points.append(current_row)
+
+        
+        self.current_point=1
+        self.n_points=len(self.points)
+        
+        self.is_random=is_random
+
+        
+        self.battery_life=100
+        self.battery_monitor=rospy.Subscriber("/battery_state", BatteryState, self.bat_cb)
+
+    def bat_cb(self,msg):
+        self.battery_life=msg.lifePercent
+        
+        
+
+    def execute(self,userdata):    
+        rospy.sleep(1)
+            
+        if self.battery_life>CHARGE_BATTERY_TRESHOLD:
+            if self.is_random:
+                self.current_point=randint(1,self.n_points-1)
+                current_row=self.points[self.current_point]
+            else:
+                current_row=self.points[self.current_point]
+                self.current_point=self.current_point+1
+                if self.current_point==self.n_points:
+                    self.current_point=1
+            userdata.goal_pose=current_row
+            userdata.going_to_charge=0
+            return 'patrol'
+        else:
+            current_row=self.points[0]
+            userdata.goal_pose=current_row
+            userdata.going_to_charge=1
+            return 'go_charge'
+        
+        
+
+
+def main():
+
+
+
+    rospy.init_node('patroller')
+
+    
+    #Check if a waypoints file was given as argument
+    if len(sys.argv)<2:
+      rospy.logerr("No waypoints file given. Use rosrun waypoint_patroller patroller.py [path to csv waypoints file]. If you are using a launch file, see launch/patroller.launch for an example.")
+      return 1
+      
+    waypoints_name=sys.argv[1]
+
+    
+    is_random=1;
+    if len(sys.argv)>2:
+      if sys.argv[2]=="false":
+	is_random=0
+	rospy.loginfo("Executing waypoint_patroller with sequential point selection.")
+      else:
+	rospy.loginfo("Executing waypoint_patroller with random point selection.")
+    else:
+      rospy.loginfo("Executing waypoint_patroller with random point selection.")
+
+	  
+  
+	
+    # Create a SMACH state machine
+    long_term_patrol_sm = smach.StateMachine(outcomes=['succeeded','aborted'])
+    with long_term_patrol_sm:
+        smach.StateMachine.add('POINT_CHOOSER', PointChooser(waypoints_name,is_random),  transitions={'patrol':'PATROL_POINT','go_charge':'GO_TO_CHARGING_STATION'})
+        smach.StateMachine.add('PATROL_POINT', navigation(),  
+                                transitions={'succeeded':'POINT_CHOOSER', 'battery_low':'POINT_CHOOSER','bumper_failure':'aborted','move_base_failure':'POINT_CHOOSER'})
+        smach.StateMachine.add('GO_TO_CHARGING_STATION', navigation(),  
+                                transitions={'succeeded':'DOCK_AND_CHARGE', 'battery_low':'GO_TO_CHARGING_STATION','bumper_failure':'aborted','move_base_failure':'aborted'})
+        smach.StateMachine.add('DOCK_AND_CHARGE',dock_and_charge() , transitions={'succeeded':'POINT_CHOOSER','failure':'aborted'})
+        
+
+    
+ 
+
+    # Execute SMACH plan
+
+    sis = smach_ros.IntrospectionServer('server_name', long_term_patrol_sm, '/SM_ROOT')
+    sis.start()
+    outcome = long_term_patrol_sm.execute()
+
+    rospy.spin()
+    sis.stop()
+
+
+if __name__ == '__main__':
+    main()
+
+
+
+
+
+
+0

--- a/waypoint_patroller/scripts/monitor_states.py
+++ b/waypoint_patroller/scripts/monitor_states.py
@@ -1,0 +1,55 @@
+import rospy
+
+import smach
+import smach_ros
+
+from smach import *
+from smach_ros import *
+
+from scitos_msgs.msg import MotorStatus
+from scitos_msgs.msg import BatteryState
+
+
+CHARGED_BATTERY=99
+LOW_BATTERY=15
+VERY_LOW_BATTERY=5
+
+
+
+#true -> continue monitor
+#false -> terminate and return 'invalid'
+def bumper_cb(ud, msg):
+    if  msg.bumper_pressed:
+        n_tries=ud.n_recover_tries_in
+        ud.n_recover_tries_out=n_tries
+        return False
+    else:
+        ud.n_recover_tries_out=0 #just to avoid warning when robot does a path without being bumped
+        return True
+                        
+
+def battery_cb(ud, msg):
+    if msg.lifePercent<VERY_LOW_BATTERY:
+        return False
+    if ud.going_to_charge:
+       return  msg.lifePercent<CHARGED_BATTERY
+    else:
+        return  msg.lifePercent>LOW_BATTERY   
+   
+            
+
+
+
+def bumper_monitor():    
+    state=smach_ros.MonitorState("/motor_status", MotorStatus, bumper_cb,input_keys=['n_recover_tries_in'],output_keys=['n_recover_tries_out'])
+    return state
+  
+     
+   
+        
+def battery_monitor():   
+    state=smach_ros.MonitorState("/battery_state", BatteryState, battery_cb,input_keys=['going_to_charge'])
+    return state
+    
+
+  

--- a/waypoint_patroller/scripts/navigation.py
+++ b/waypoint_patroller/scripts/navigation.py
@@ -1,0 +1,128 @@
+import rospy
+
+import smach
+import smach_ros
+
+import actionlib
+from actionlib_msgs.msg import *
+from move_base_msgs.msg import *
+
+
+from monitor_states import battery_monitor
+from monitor_states import bumper_monitor
+from recover_states import RecoverMoveBase
+from recover_states import RecoverBumper
+
+
+        
+                
+        
+
+
+def child_term_cb(outcome_map):
+    if outcome_map['BUMPER_MONITOR'] == 'invalid' or outcome_map["BATTERY_MONITOR"]=="invalid" or outcome_map["MOVE_BASE_SM"]=="succeeded":
+        return True
+    return False
+
+    
+def out_cb(outcome_map):
+    rospy.sleep(0.1)
+    if outcome_map['BUMPER_MONITOR'] == 'invalid':
+        return 'bumper_pressed'
+    if  outcome_map["BATTERY_MONITOR"]=="invalid":
+        return "battery_low"
+    if outcome_map["MOVE_BASE_SM"]=="succeeded":
+        return "succeeded"
+
+        
+        
+def move_base_goal_cb(userdata,goal):
+    
+    next_goal = move_base_msgs.msg.MoveBaseGoal()            
+    next_goal.target_pose.header.frame_id = "/map"
+    next_goal.target_pose.header.stamp = rospy.Time.now()
+    next_goal.target_pose.pose.position.x=userdata.goal_pose[0]
+    next_goal.target_pose.pose.position.y=userdata.goal_pose[1]
+    next_goal.target_pose.pose.position.z=userdata.goal_pose[2]
+    next_goal.target_pose.pose.orientation.x=userdata.goal_pose[3]
+    next_goal.target_pose.pose.orientation.y=userdata.goal_pose[4]
+    next_goal.target_pose.pose.orientation.z=userdata.goal_pose[5]
+    next_goal.target_pose.pose.orientation.w=userdata.goal_pose[6]
+    
+    return next_goal
+    
+
+def move_base_result_cb(userdata,status,result):
+    if status==4: #aborted
+        userdata.fails=userdata.fails+1
+    else:
+        if status==3: #succeeded
+            userdata.fails=0    
+    
+   
+
+def move_base_sm():
+    sm=smach.StateMachine(outcomes=['succeeded','failure','preempted'], input_keys=['goal_pose'])
+    
+    with sm:
+        
+        sm.userdata.fails=0
+        
+        smach.StateMachine.add('MOVE_BASE',
+                      smach_ros.SimpleActionState('move_base',
+                                        MoveBaseAction,
+                                        goal_cb=move_base_goal_cb,
+                                        result_cb=move_base_result_cb,
+                                        input_keys=['goal_pose','fails'],
+                                        output_keys=['fails']),
+                      transitions={'succeeded':'succeeded','aborted':'RECOVER_MOVE_BASE','preempted':'preempted'},
+                      #remapping={'gripper_input':'userdata_input'}
+                      )
+        smach.StateMachine.add('RECOVER_MOVE_BASE', RecoverMoveBase(),  transitions={'succeeded':'MOVE_BASE'})
+        
+    return sm
+        
+        
+def navigation(): 
+
+
+        sm=smach.StateMachine(outcomes=['succeeded','bumper_failure','move_base_failure','battery_low'], input_keys=['goal_pose','going_to_charge'])
+        sm.userdata.cur_tries = 0
+        sm.userdata.prev_tries = 0
+        with sm:
+                    
+            monitored_move_base=smach.Concurrence(outcomes=['bumper_pressed','battery_low','succeeded','failure'],
+                                                default_outcome='failure',
+                                                child_termination_cb=child_term_cb,
+                                                outcome_cb = out_cb,
+                                                input_keys=[ 'goal_pose','going_to_charge','n_recover_tries_in'],
+                                                output_keys=['n_recover_tries_out']
+                                                )
+        
+            with monitored_move_base:
+                smach.Concurrence.add('BATTERY_MONITOR', battery_monitor())
+                smach.Concurrence.add('BUMPER_MONITOR',bumper_monitor())
+                smach.Concurrence.add('MOVE_BASE_SM',move_base_sm()
+                            #remapping={'gripper_input':'userdata_input'}
+                            )
+            
+            smach.StateMachine.add('MONITORED_MOVE_BASE',monitored_move_base,transitions={'bumper_pressed':'RECOVER_BUMPER','battery_low':'battery_low','succeeded':'succeeded','failure':'move_base_failure'},
+                                    remapping={'n_recover_tries_out':'prev_tries', 'n_recover_tries_in':'cur_tries'})
+            smach.StateMachine.add('RECOVER_BUMPER', RecoverBumper(),  transitions={'succeeded':'MONITORED_MOVE_BASE','failure':'bumper_failure'},
+                                    remapping={'n_recover_tries_in':'prev_tries', 'n_recover_tries_out':'cur_tries'})
+             
+        return sm
+          
+
+          
+
+          
+
+    
+    
+    
+    
+    
+    
+    
+    

--- a/waypoint_patroller/scripts/recover_states.py
+++ b/waypoint_patroller/scripts/recover_states.py
@@ -1,0 +1,73 @@
+import rospy
+
+import smach
+import smach_ros
+
+
+from scitos_msgs.srv import ResetMotorStop
+from scitos_msgs.msg import MotorStatus
+
+
+from geometry_msgs.msg import Twist
+
+MAX_BUMPER_RECOVERY_ATTEMPTS=5
+MAX_MOVE_BASE_RECOVERY_ATTEMPTS=5
+
+
+class RecoverMoveBase(smach.State):
+    def __init__(self):
+        smach.State.__init__(self,
+            outcomes    = ['succeeded','failure'], input_keys=['fails']
+        )
+        self.vel_pub = rospy.Publisher('/cmd_vel', Twist)
+        self._vel_cmd = Twist()
+        self._vel_cmd.linear.x=-0.1
+
+
+    def execute(self,userdata):
+        if userdata.fails<MAX_MOVE_BASE_RECOVERY_ATTEMPTS:
+            for i in range(0,20): 
+                self.vel_pub.publish(self._vel_cmd)
+                if self.preempt_requested():
+                    self.service_preempt()
+                    return 'preempted'
+                rospy.sleep(0.1)
+                return 'succeeded'
+        else:
+            return 'failure'
+        
+        
+        
+
+class RecoverBumper(smach.State):
+    def __init__(self):
+        smach.State.__init__(self,
+            outcomes    = ['succeeded','failure'],
+            input_keys=['n_recover_tries_in'],
+            output_keys=['n_recover_tries_out']
+        )
+        self.reset_motorstop = rospy.ServiceProxy('reset_motorstop', ResetMotorStop)
+        self.is_recovered=False
+        self.motor_monitor=rospy.Subscriber("/motor_status", MotorStatus, self.bumper_cb)
+
+                
+
+
+    def bumper_cb(self,msg):
+        self.isRecovered=not msg.bumper_pressed
+
+    def execute(self,userdata):
+        n_tries=userdata.n_recover_tries_in
+        if n_tries<MAX_BUMPER_RECOVERY_ATTEMPTS:
+            n_tries=n_tries+1
+            rospy.sleep(3*n_tries)
+            self.reset_motorstop()
+            rospy.sleep(0.1)
+            if self.isRecovered:
+                userdata.n_recover_tries_out=0
+            else:           
+                userdata.n_recover_tries_out=n_tries
+            return 'succeeded'
+        else:
+            return 'failure'
+        


### PR DESCRIPTION
- The old version of the patroller is still here, just run it as before
- To run  the new long term patroller, you need to replace the smach in your system by trhe one just forked into the strands-project, then follow the same procedure as for the patroller but  use:
  
    roslaunch waypoint_patroller long_term_patroller.launch
  
  WARNING: When creating the waypoints file, the first waypoint should be the one in front of the charging station
- You can also use rosrun smach_viewer smach_viewer.py to see the state machine execution. Comments on its structure are welcome
-  I'll review the readme, improve some details and comment the code briefly
