### PR TITLE
Waypoint recorder now subscribes to "robot_pose" instead of "acml_pose"

### DIFF
--- a/waypoint_recorder/src/waypoint_recorder.cpp
+++ b/waypoint_recorder/src/waypoint_recorder.cpp
@@ -6,6 +6,7 @@
 
 #include "ap_msgs/SaveWaypoint.h"
 #include "ap_msgs/SaveWaypointFile.h"
+#include <tf/transform_listener.h>
 
 #include <ctime>
 #include <vector>
@@ -69,24 +70,24 @@ bool saveWaypointFile(ap_msgs::SaveWaypointFile::Request  &req,
 	return true;
 }
 
-void amclCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& msg)
+void amclCallback(const geometry_msgs::Pose::ConstPtr& msg)
 {
   if(save_pose) {
 	  std::vector<float> point(7);
-	  point[0] = msg->pose.pose.position.x;
-	  point[1] = msg->pose.pose.position.y;
-	  point[2] = msg->pose.pose.position.z;
-	  point[3] = msg->pose.pose.orientation.x;
-	  point[4] = msg->pose.pose.orientation.y;
-	  point[5] = msg->pose.pose.orientation.z;
-	  point[6] = msg->pose.pose.orientation.w;
-    ROS_INFO("New waypoint added at: x:%f y:%f z:%f ...", msg->pose.pose.position.x,
-    	      msg->pose.pose.position.y,
-    	      msg->pose.pose.position.z);
-    ROS_INFO("... with orientation: x:%f y:%f z:%f w:%f", msg->pose.pose.orientation.x,
-    	      msg->pose.pose.orientation.y,
-    	      msg->pose.pose.orientation.z,
-    	      msg->pose.pose.orientation.w);
+	  point[0] = msg->position.x;
+	  point[1] = msg->position.y;
+	  point[2] = msg->position.z;
+	  point[3] = msg->orientation.x;
+	  point[4] = msg->orientation.y;
+	  point[5] = msg->orientation.z;
+	  point[6] = msg->orientation.w;
+    ROS_INFO("New waypoint added at: x:%f y:%f z:%f ...", msg->position.x,
+    	      msg->position.y,
+    	      msg->position.z);
+    ROS_INFO("... with orientation: x:%f y:%f z:%f w:%f", msg->orientation.x,
+    	      msg->orientation.y,
+    	      msg->orientation.z,
+    	      msg->orientation.w);
     points.push_back(point);
     save_pose = false;
   }
@@ -159,7 +160,7 @@ int main(int argc, char **argv)
 #if WITH_TELEOP
   	  ros::Subscriber sub = n.subscribe("/teleop_joystick/action_buttons", 1000, controlCallback);
 #endif
-  ros::Subscriber sub_amcl = n.subscribe("/amcl_pose", 1000, amclCallback);
+  ros::Subscriber sub_amcl = n.subscribe("/robot_pose", 1000, amclCallback);
   ros::ServiceServer waypoint = n.advertiseService("SaveWaypoint", saveWaypoint);
   ros::ServiceServer waypoint_file = n.advertiseService("SaveWaypointFile", saveWaypointFile);
 	

--- a/waypoint_recorder/src/waypoint_recorder.cpp
+++ b/waypoint_recorder/src/waypoint_recorder.cpp
@@ -6,7 +6,6 @@
 
 #include "ap_msgs/SaveWaypoint.h"
 #include "ap_msgs/SaveWaypointFile.h"
-#include <tf/transform_listener.h>
 
 #include <ctime>
 #include <vector>


### PR DESCRIPTION
The "acml_pose" topic gets updated only when the robot moves a substantial distance (0.5m ?).
Therefore, the waypoints cannot be specified exactly at the place the user requires.
Using the "robot_pose" topic, (which is updated at 10Hz) instead of "acml_pose" allows to save the waypoint coordinates whenever and wherever the users wants.
