### PR TITLE
Mileage

### DIFF
--- a/waypoint_patroller/scripts/web_publisher.py
+++ b/waypoint_patroller/scripts/web_publisher.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     while True:
         try:
             create_sumary_file(options.datacentre, options.datacentre_port,options.jsonfile,
-                               start_time=datetime.datetime.strptime('Nov 18 2013  9:00AM', '%b %d %Y %I:%M%p'))
+                               start_time=datetime.datetime.strptime('Nov 25 2013  10:00AM', '%b %d %Y %I:%M%p'))
 
             if options.hostname != None:
                 upload_summary_scp(options.path, options.hostname, options.username, options.password,options.jsonfile)

--- a/waypoint_patroller/src/waypoint_patroller/logger.py
+++ b/waypoint_patroller/src/waypoint_patroller/logger.py
@@ -60,14 +60,20 @@ class PatrollLogger(Logger):
         
         self._mileage_sub = rospy.Subscriber('/mileage', Float32,
                                              self._mileage_cb)
+        self._odom_mileage_sub = rospy.Subscriber('/odom_mileage', Float32,
+                                             self._mileage_cb)
         self._batterystate_sub = rospy.Subscriber('/battery_state', BatteryState,
                                              self._batterystate_cb)
         self._mileage = 0
+        self._odom_mileage = 0
         self._battery = 100
         
 
     def _mileage_cb(self, msg):
         self._mileage = msg.data
+
+    def _odom_mileage_cb(self, msg):
+        self._odom_mileage = msg.data
         
     def _batterystate_cb(self, msg):
         self._battery = msg.lifePercent
@@ -83,6 +89,7 @@ class PatrollLogger(Logger):
         if self._active_episode:
             doc['episode_name'] = self._episode_name
             doc['mileage'] = self._mileage
+            doc['odom_mileage'] = self._odom_mileage
             doc['battery level'] = self._battery
             self._db.insert(self._stamp(doc))
         

--- a/waypoint_patroller/src/waypoint_patroller/logger.py
+++ b/waypoint_patroller/src/waypoint_patroller/logger.py
@@ -61,7 +61,7 @@ class PatrollLogger(Logger):
         self._mileage_sub = rospy.Subscriber('/mileage', Float32,
                                              self._mileage_cb)
         self._odom_mileage_sub = rospy.Subscriber('/odom_mileage', Float32,
-                                             self._mileage_cb)
+                                             self._odom_mileage_cb)
         self._batterystate_sub = rospy.Subscriber('/battery_state', BatteryState,
                                              self._batterystate_cb)
         self._mileage = 0


### PR DESCRIPTION
This adds logging of odom_mileage. If odom_mileage is not being published because the node was not started, then zeros will be logged. The EEPROM mileage is still logged as the primary.

I propose that we keep with using /mileage as the main measure for the marathon next week, but log odom mileage too for later comparison.  
